### PR TITLE
Add support for cloudtrail log file prefix

### DIFF
--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -148,4 +148,5 @@ func init() {
 	analyzeCmd.Flags().StringSliceVarP(&opt.Regions, "region", "r", []string{}, "target region")
 	analyzeCmd.Flags().BoolVarP(&opt.AllAccounts, "all-accounts", "A", false, "all accounts")
 	analyzeCmd.Flags().BoolVarP(&opt.AllRegions, "all-regions", "R", false, "all regions")
+	analyzeCmd.Flags().StringVarP(&opt.LogFilePrefix, "log-file-prefix", "p", "", "log file prefix")
 }

--- a/cmd/events.go
+++ b/cmd/events.go
@@ -64,4 +64,5 @@ func init() {
 	eventsCmd.Flags().StringSliceVarP(&opt.Regions, "region", "r", []string{}, "target region")
 	eventsCmd.Flags().BoolVarP(&opt.AllAccounts, "all-accounts", "A", false, "all accounts")
 	eventsCmd.Flags().BoolVarP(&opt.AllRegions, "all-regions", "R", false, "all regions")
+	eventsCmd.Flags().StringVarP(&opt.LogFilePrefix, "log-file-prefix", "p", "", "log file prefix")
 }

--- a/cmd/size.go
+++ b/cmd/size.go
@@ -125,4 +125,5 @@ func init() {
 	sizeCmd.Flags().StringSliceVarP(&opt.Regions, "region", "r", []string{}, "target region")
 	sizeCmd.Flags().BoolVarP(&opt.AllAccounts, "all-accounts", "A", false, "all accounts")
 	sizeCmd.Flags().BoolVarP(&opt.AllRegions, "all-regions", "R", false, "all regions")
+	sizeCmd.Flags().StringVarP(&opt.LogFilePrefix, "log-file-prefix", "p", "", "log file prefix")
 }

--- a/trail/trail.go
+++ b/trail/trail.go
@@ -86,6 +86,7 @@ type Option struct {
 	Regions       []string
 	AllAccounts   bool
 	AllRegions    bool
+	LogFilePrefix string
 }
 
 type WalkEventsFunc func(r *Record) error
@@ -231,6 +232,9 @@ func generatePrefixes(sess *session.Session, dsn string, opt Option, after1Day b
 	}
 	bucket := splitted[0]
 	prefix := "AWSLogs"
+	if opt.LogFilePrefix != "" {
+		prefix = fmt.Sprintf("%s/%s", opt.LogFilePrefix, prefix)
+	}
 	if len(splitted) > 1 && splitted[1] != "" {
 		prefix = splitted[1]
 	}


### PR DESCRIPTION
When creating a trail, using an existing S3 bucket, you have the option of specifying a prefix.
This prefix shows up in the Cloudtrail -> Trails tab under the table header "Log file prefix".
Currently, trail-digger does not support prefixes.

This PR adds a flag for all commands allowing you to specify a log file prefix.